### PR TITLE
Add gallery page

### DIFF
--- a/catalogo-arqueologico/src/pages/Gallery/Gallery.jsx
+++ b/catalogo-arqueologico/src/pages/Gallery/Gallery.jsx
@@ -1,12 +1,104 @@
-import React from 'react';
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Box, Button, Container, Grid, Typography } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import ArtifactCard from "./components/ArtifactCard";
+import CustomPagination from "./components/CustomPagination";
+import CustomFilter from "./components/CustomFilter";
 
-const Gallery = () => {
-    return (
-        <div>
-            <h1>Welcome to the Gallery page!</h1>
-            {/* Add your content here */}
-        </div>
-    );
+const Gallery = ({ loggedIn }) => {
+  const navigate = useNavigate();
+
+  // Retrieved data from the API
+  const [artifactList, setArtifactList] = useState([]);
+
+  // Filtered artifacts
+  const [filteredArtifacts, setFilteredArtifacts] = useState([]);
+  // Sliced artifacts to display on the current page
+  const [artifactsToDisplay, setArtifactsToDisplay] = useState([]);
+
+  // Fetch data from the API
+  useEffect(() => {
+    fetch("/pieces_models/response.json")
+      .then((response) => response.json())
+      .then((response) => {
+        let artifacts = response.data;
+
+        let artifactsSimplified = artifacts.map((artifact) => {
+          let { id, attributes, preview } = artifact;
+          return {
+            id,
+            attributes,
+            preview,
+          };
+        });
+        setArtifactList(artifactsSimplified);
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  const handleRedirect = () => {
+    navigate("/gallery/new");
+  };
+
+  return (
+    <Container>
+      <CustomTypography variant="h1">Galería</CustomTypography>
+      <CustomFilter
+        artifactList={artifactList}
+        setFilteredArtifacts={setFilteredArtifacts}
+      />
+      {loggedIn && (
+        <CustomBox>
+          <Button
+            variant="contained"
+            color="primary"
+            size="large"
+            onClick={handleRedirect}
+          >
+            Agregar objeto
+          </Button>
+        </CustomBox>
+      )}
+      {filteredArtifacts.length > 0 ? (
+        <Box>
+          <Grid container spacing={2}>
+            {artifactsToDisplay.map((artifact) => (
+              <Grid item xs={12} sm={6} md={4} key={artifact.id}>
+                <ArtifactCard artifact={artifact} />
+              </Grid>
+            ))}
+          </Grid>
+
+          <CustomPagination
+            items={filteredArtifacts}
+            setDisplayedItems={setArtifactsToDisplay}
+          />
+        </Box>
+      ) : (
+        <CustomBox>
+          <Typography variant="p" align="center">
+            No se encontraron resultados
+          </Typography>
+        </CustomBox>
+      )}
+    </Container>
+  );
 };
+
+const CustomTypography = styled(Typography)(({ theme }) => ({
+  marginTop: theme.spacing(12),
+  marginBottom: theme.spacing(3),
+  textAlign: "center",
+}));
+
+const CustomBox = styled(Grid)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: theme.spacing(2),
+  marginBottom: theme.spacing(3),
+}));
 
 export default Gallery;

--- a/catalogo-arqueologico/src/pages/Gallery/components/ArtifactCard.jsx
+++ b/catalogo-arqueologico/src/pages/Gallery/components/ArtifactCard.jsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Chip,
+  Typography,
+  Box,
+} from "@mui/material";
+import { styled } from "@mui/material/styles";
+
+const ArtifactCard = ({ artifact }) => {
+  const navigate = useNavigate();
+  const { id, attributes, preview: previewPath } = artifact;
+  const { shape, tags, culture, description } = attributes;
+
+  const artifactNumber = String(id).padStart(4, "0");
+  const fullTitle = `#${artifactNumber} ${description}`;
+  const fullDescription = tags.join(", ");
+
+  const handleRedirect = () => {
+    navigate(`/gallery/${id}`);
+  };
+
+  return (
+    <Card>
+      <CustomCardMedia
+        component="img"
+        height="140"
+        image={previewPath}
+        alt={id}
+        onClick={handleRedirect}
+      />
+      <CustomCardContent>
+        <CustomBox>
+          <CardTitle variant="p">{fullTitle}</CardTitle>
+        </CustomBox>
+        <CustomBox>
+          <CardDescription variant="p">{fullDescription}</CardDescription>
+        </CustomBox>
+        <MetadataContainer>
+          <CustomShapeTag label={shape} size="small" />
+          <CustomCultureTag label={culture} size="small" />
+        </MetadataContainer>
+      </CustomCardContent>
+    </Card>
+  );
+};
+
+const CustomCardMedia = styled(CardMedia)(({ theme }) => ({
+  cursor: "pointer",
+}));
+
+const CustomBox = styled(Box)(({ theme }) => ({
+  width: "100%",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+}));
+
+const CustomCardContent = styled(CardContent)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  rowGap: 5,
+}));
+
+const CardTitle = styled(Typography)(({ theme }) => ({
+  fontWeight: "bold",
+  fontSize: 18,
+}));
+
+const CardDescription = styled(Typography)(({ theme }) => ({
+  fontSize: 10,
+}));
+
+const MetadataContainer = styled(Box)(({ theme }) => ({
+  display: "flex",
+  flexWrap: "wrap",
+  flexDirection: "row",
+  gap: theme.spacing(1),
+}));
+
+const CustomShapeTag = styled(Chip)(({ theme }) => ({
+  backgroundColor: theme.palette.tags.shape,
+  fontSize: 10,
+}));
+
+const CustomCultureTag = styled(Chip)(({ theme }) => ({
+  backgroundColor: theme.palette.tags.culture,
+  fontSize: 10,
+}));
+
+export default ArtifactCard;

--- a/catalogo-arqueologico/src/pages/Gallery/components/CustomFilter.jsx
+++ b/catalogo-arqueologico/src/pages/Gallery/components/CustomFilter.jsx
@@ -1,0 +1,237 @@
+import React, { useState, useEffect } from "react";
+import { Autocomplete, TextField, Grid, Stack } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+import { styled } from "@mui/system";
+import { useSearchParams } from "react-router-dom";
+
+const CustomFilter = ({ artifactList, setFilteredArtifacts }) => {
+  // Search params from the URL
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Avoid updating the search params when the component mounts and there are search params
+  const [updateParamsFlag, setUpdateParamsFlag] = useState(false);
+
+  // Retrieved data from the API
+  const [shapeOptions, setShapeOptions] = useState([]);
+  const [cultureOptions, setCultureOptions] = useState([]);
+  const [tagOptions, setTagOptions] = useState([]);
+
+  // Filter state
+  const [filter, setFilter] = useState({
+    query: "",
+    shape: "",
+    culture: "",
+    tags: [],
+  });
+
+  const handleFilterChange = (name, value) => {
+    setFilter({ ...filter, [name]: value });
+  };
+
+  // Initialize the filter state with the search params
+  useEffect(() => {
+    const query = searchParams.get("query")
+      ? decodeURIComponent(searchParams.get("query"))
+      : "";
+    const shape = searchParams.get("shape")
+      ? decodeURIComponent(searchParams.get("shape"))
+      : "";
+    const culture = searchParams.get("culture")
+      ? decodeURIComponent(searchParams.get("culture"))
+      : "";
+    const tags = searchParams.get("tags")
+      ? decodeURIComponent(searchParams.get("tags"))
+      : "";
+    const tagsArray = tags?.split(",").filter((tag) => tag);
+    setFilter({ query, shape, culture, tags: tagsArray });
+    setUpdateParamsFlag(true);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch data from the API
+  useEffect(() => {
+    fetch("/pieces_models/response.json")
+      .then((response) => response.json())
+      .then((response) => {
+        let artifacts = response.data;
+
+        let shapes = new Set();
+        let cultures = new Set();
+        let tags = new Set();
+
+        artifacts.forEach((artifact) => {
+          let { attributes } = artifact;
+          let { shape, culture, tags: artifactTags } = attributes;
+          shapes.add(shape);
+          cultures.add(culture);
+          artifactTags.forEach((tag) => tags.add(tag));
+        });
+
+        setShapeOptions(Array.from(shapes));
+        setCultureOptions(Array.from(cultures));
+        setTagOptions(Array.from(tags));
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  // Filter artifacts based on the filter state
+  useEffect(() => {
+    let filtered = artifactList.filter((artifact) => {
+      const { shape, culture, tags } = artifact.attributes;
+      const {
+        query,
+        shape: filterShape,
+        culture: filterCulture,
+        tags: filterTags,
+      } = filter;
+
+      if (query && !artifact.attributes.description.includes(query)) {
+        return false;
+      }
+
+      if (filterShape && shape !== filterShape) {
+        return false;
+      }
+
+      if (filterCulture && culture !== filterCulture) {
+        return false;
+      }
+
+      if (
+        filterTags.length > 0 &&
+        !filterTags.every((tag) => tags.includes(tag))
+      ) {
+        return false;
+      }
+
+      return true;
+    });
+    setFilteredArtifacts(filtered);
+  }, [filter, artifactList]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Update the URL search params when the user applies a filter
+  useEffect(() => {
+    if (!updateParamsFlag) {
+      return;
+    }
+    if (filter.query) {
+      searchParams.set("query", filter.query);
+    } else {
+      searchParams.delete("query");
+    }
+    if (filter.shape) {
+      searchParams.set("shape", filter.shape);
+    } else {
+      searchParams.delete("shape");
+    }
+    if (filter.culture) {
+      searchParams.set("culture", filter.culture);
+    } else {
+      searchParams.delete("culture");
+    }
+    if (filter.tags.length > 0) {
+      searchParams.set("tags", filter.tags.join(","));
+    } else {
+      searchParams.delete("tags");
+    }
+    setSearchParams(searchParams);
+  }, [filter]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <CustomBox>
+      <TextField
+        InputProps={{ startAdornment: <SearchIcon /> }}
+        label="Buscar"
+        variant="outlined"
+        size="small"
+        fullWidth
+        name="query"
+        value={filter.query}
+        onChange={(event) =>
+          handleFilterChange(event.target.name, event.target.value)
+        }
+      />
+      <CustomStack direction="row">
+        <Autocomplete
+          fullWidth
+          id="shape"
+          name="shape"
+          value={filter.shape}
+          onChange={(value) =>
+            handleFilterChange("shape", value.target.textContent)
+          }
+          options={shapeOptions}
+          getOptionLabel={(option) => option}
+          filterSelectedOptions
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Forma"
+              placeholder="Filtrar por forma"
+            />
+          )}
+        />
+        <Autocomplete
+          fullWidth
+          id="culture"
+          name="culture"
+          value={filter.culture}
+          onChange={(value) =>
+            handleFilterChange("culture", value.target.textContent)
+          }
+          options={cultureOptions}
+          getOptionLabel={(option) => option}
+          filterSelectedOptions
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Cultura"
+              placeholder="Filtrar por cultura"
+            />
+          )}
+        />
+        <Autocomplete
+          multiple
+          limitTags={2}
+          fullWidth
+          sx={{
+            maxHeight: "56px",
+          }}
+          id="tags"
+          name="tags"
+          value={filter.tags}
+          onChange={(event, value) =>
+            handleFilterChange(
+              "tags",
+              value.map((tag) => tag)
+            )
+          }
+          options={tagOptions}
+          getOptionLabel={(option) => option}
+          filterSelectedOptions
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Etiquetas"
+              placeholder="Filtrar por etiquetas"
+            />
+          )}
+        />
+      </CustomStack>
+    </CustomBox>
+  );
+};
+
+const CustomBox = styled(Grid)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: theme.spacing(2),
+  marginBottom: theme.spacing(3),
+}));
+
+const CustomStack = styled(Stack)(({ theme }) => ({
+  width: "100%",
+  columnGap: theme.spacing(2),
+}));
+
+export default CustomFilter;

--- a/catalogo-arqueologico/src/pages/Gallery/components/CustomFilter.jsx
+++ b/catalogo-arqueologico/src/pages/Gallery/components/CustomFilter.jsx
@@ -1,6 +1,14 @@
 import React, { useState, useEffect } from "react";
-import { Autocomplete, TextField, Grid, Stack } from "@mui/material";
+import {
+  Autocomplete,
+  TextField,
+  Grid,
+  Stack,
+  InputAdornment,
+  IconButton,
+} from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
+import Clear from "@mui/icons-material/Clear";
 import { styled } from "@mui/system";
 import { useSearchParams } from "react-router-dom";
 
@@ -85,7 +93,13 @@ const CustomFilter = ({ artifactList, setFilteredArtifacts }) => {
 
       const filterTagsInLowerCase = filterTags.map((tag) => tag.toLowerCase());
 
-      if (query && !artifact.attributes.description.toLowerCase().includes(query.toLowerCase())) {
+      if (
+        query &&
+        !artifact.attributes.description
+          .toLowerCase()
+          .includes(query.toLowerCase()) &&
+        !query.includes(String(artifact.id))
+      ) {
         return false;
       }
 
@@ -93,7 +107,10 @@ const CustomFilter = ({ artifactList, setFilteredArtifacts }) => {
         return false;
       }
 
-      if (filterCulture && culture.toLowerCase() !== filterCulture.toLowerCase()) {
+      if (
+        filterCulture &&
+        culture.toLowerCase() !== filterCulture.toLowerCase()
+      ) {
         return false;
       }
 
@@ -140,7 +157,26 @@ const CustomFilter = ({ artifactList, setFilteredArtifacts }) => {
   return (
     <CustomBox>
       <TextField
-        InputProps={{ startAdornment: <SearchIcon /> }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          ),
+          endAdornment: filter.query && (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="Clear search"
+                onClick={() => handleFilterChange("query", "")}
+                onMouseDown={(event) => event.preventDefault()}
+                edge="end"
+                size="small"
+              >
+                <Clear />
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
         label="Buscar"
         variant="outlined"
         size="small"

--- a/catalogo-arqueologico/src/pages/Gallery/components/CustomFilter.jsx
+++ b/catalogo-arqueologico/src/pages/Gallery/components/CustomFilter.jsx
@@ -83,21 +83,23 @@ const CustomFilter = ({ artifactList, setFilteredArtifacts }) => {
         tags: filterTags,
       } = filter;
 
-      if (query && !artifact.attributes.description.includes(query)) {
+      const filterTagsInLowerCase = filterTags.map((tag) => tag.toLowerCase());
+
+      if (query && !artifact.attributes.description.toLowerCase().includes(query.toLowerCase())) {
         return false;
       }
 
-      if (filterShape && shape !== filterShape) {
+      if (filterShape && shape.toLowerCase() !== filterShape.toLowerCase()) {
         return false;
       }
 
-      if (filterCulture && culture !== filterCulture) {
+      if (filterCulture && culture.toLowerCase() !== filterCulture.toLowerCase()) {
         return false;
       }
 
       if (
-        filterTags.length > 0 &&
-        !filterTags.every((tag) => tags.includes(tag))
+        filterTagsInLowerCase.length > 0 &&
+        !filterTagsInLowerCase.every((tag) => tags.includes(tag.toLowerCase()))
       ) {
         return false;
       }

--- a/catalogo-arqueologico/src/pages/Gallery/components/CustomPagination.jsx
+++ b/catalogo-arqueologico/src/pages/Gallery/components/CustomPagination.jsx
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from "react";
+import { Box, Pagination } from "@mui/material";
+
+const CustomPagination = ({ items, setDisplayedItems }) => {
+  const itemsPerPage = 6; // Set the number of items per page
+  const totalItems = items.length; // Get the total number of items
+  const totalPages = Math.ceil(totalItems / itemsPerPage); // Calculate the total number of pages
+
+  const [currentPage, setCurrentPage] = useState(1); // Set the current page initially to 1
+
+  const startIndex = (currentPage - 1) * itemsPerPage; // Calculate the start index of the items to display
+  const endIndex = startIndex + itemsPerPage; // Calculate the end index of the items to display
+  const displayedItems = items.slice(startIndex, endIndex); // Get the items to display on the current page
+
+  const handlePageChange = (event, page) => {
+    setCurrentPage(page);
+  };
+
+  // Update the displayed items when the list or currentPage changes
+  useEffect(() => {
+    setDisplayedItems(displayedItems);
+  }, [items, currentPage]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Reset the current page to 1 when the list changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [items]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <Box display="flex" justifyContent="center" p={2}>
+      <Pagination
+        count={totalPages}
+        page={currentPage}
+        onChange={handlePageChange}
+        color="primary"
+      />
+    </Box>
+  );
+};
+
+export default CustomPagination;

--- a/catalogo-arqueologico/src/styles.js
+++ b/catalogo-arqueologico/src/styles.js
@@ -11,6 +11,8 @@ const COLORS = {
   AZUL2: "#1B98E0",
   AZUL3: "#006494",
   AZUL4: "#13293D",
+  CULTURE:"#FEE2DD",
+  SHAPE:"#D2E5EF"
 };
 
 // Define theme colors and typography
@@ -25,6 +27,10 @@ let theme = createTheme({
     footer: {
       main: COLORS.AZUL4,
     },
+    tags: {
+      culture: COLORS.CULTURE,
+      shape: COLORS.SHAPE,
+    }
   },
   typography: {
     h1: {
@@ -55,7 +61,8 @@ theme = createTheme(theme, {
         main: COLORS.AZUL3,
       },
       name: "secondary",
-    }),
+    }    
+    ),
   },
 });
 


### PR DESCRIPTION
<img width="1203" alt="Captura de pantalla 2024-05-18 a la(s) 9 35 50 p  m" src="https://github.com/camilaF2022/Catalogo/assets/38821553/6d533738-404c-4aac-ba1a-5f007c5a8255">

Added gallery page with filters and paginated items.
* Filters are saved in the URL to be able to access them in a next session.
* Items are paginated to avoid large vertical scrolling.
* You can filter shapes, cultures and tags by typing their name in the text fields.
* Filtering items goes back to the first page to avoid empty lists.
* A button has been added to create new items when logging in.
* Clicking on an item redirects to its details.
